### PR TITLE
Proposed changes §2-§2.3.2.2

### DIFF
--- a/2.Core_Mechanics.md
+++ b/2.Core_Mechanics.md
@@ -45,60 +45,63 @@ You start the game with a pool of 3 hero points, and gain three more of them at 
 
 Any Hero Points not spent on boosting contest results or improving your character do not carry over to the next session.
 
-## 2.3 Procedure
+## 2.3 Contest Procedure
 
-You choose an ability relevant to the conflict at hand, describes exactly what you are trying to accomplish, and how. Your GM may modify these suggested actions to better fit the fictional circumstances, and describe the actions of the NPCs or forces on the other side of the conflict.
+You choose an ability relevant to the conflict at hand, describe exactly what you are trying to accomplish, and how. Your GM may modify these suggested actions to better fit the fictional circumstances, and describe the actions of the NPCs or forces on the other side of the conflict.
 
 ### 2.3.1 Resolution Methods
 
 The core resolution methods are as follows:
 
-#### 2.3.1.1 Automatic Success
+#### 2.3.1.1 Automatic Victory
 
-You simply succeed. This may indicate that failure would not be interesting (such as finding an important clue when you have an ability, such as Forensic Science, that it is credible could help to uncover that clue), or that failure would make you appear to be incompetent at a trivial or simple task for someone with that ability (such as a hunter bringing in the evening meal in a forest filled with game animals).
+Sometimes, your GM may not call for a contest at all, in which case you are simply victorious in overcoming the obstacle at hand. This may be because defeat in the conflict to overcome the obstacle would lead to uninteresting results or a narrative dead-end, such as when finding an important clue is essential to the progress of an adventure. 
 
-Your GM will use Automaric Success only when you have a relevant ability. If you have no relevant ability, you should find an alternate way to overcome the obstacle.
+Your GM might also do this in cases where, within the fictional context, the particular ability you have brought to bear on the obstacle is such that overcoming the obstacle should be a trivial matter under normal circumstances (e.g. - a professional hunter bringing in the evening meal in a forest filled with game animals). In such cases, defeat would simply not be credible unless your GM wanted to introduce some further complications to the story. Generally, your GM will only use Automaric Victory when you have a relevant ability to justify its application.
+
+For cases where overall victory may be a given, but the degree, timeliness, or cost of that victory may be interesting concerns, consider the optional rules in §4.12.
 
 #### 2.3.1.2 Simple Contest
 
-You rolls a 20-sided die; your GM does the same. 
+The simple contest QuestWorlds's primary resolution mechanic for overcoming story obstacles, and is used the most often. It also provides the foundation for other types of contests, including several optional ones. As such, it receives both an overview of key concepts here as well as a more detailed treatment in §5.
 
-Your GM compares the two results, and determines success or failure. Armed with this knowledge, they describes the outcome of the conflict, and any consequences to either participant.
+At is most basic, a simple contest can be summarized as follows:
+1. You and your GM agree upon the terms of the contest.
+2. You roll a D20 vs your relevant ability, while your GM rolls a D20 vs the contest's resistance.
+3. Your GM compares the success or failure of the two rolls, and assesses your overall victory or defeat.
+4. Your GM then narrates the outcome of the conflict as appropriate.
 
-If you enter into conflict with one player, you both roll dice, and your GM interprets the results, as usual.
+If you enter into conflict with another player rather than an obstacle presented by your GM, you both roll your relevant abilities for the contest instaid of against a GM-set resistance, and your GM interprets the results, as described above.
 
-More detail on Simple Contests is provided in their own section.
 
 ### 2.3.2 Framing the Contest
 
 #### 2.3.2.1 Framing the Contest
 
-You and your GM start by clearly agreeing on: 
-
+When a conflict arises during the game, you and your GM start by clearly agreeing on: 
+* What goal you are trying to achieve.
 * What the obstacle is you are trying to overcome 
 * What tactics you are using to and overcome it. 
 
 This process is called 'Framing the Contest'.
 
-#### 2.3.2.2 Obstacles
+#### 2.3.2.2 Conflict: Goals vs Obstacles
 
-Contests in QuestWorlds don’t simply tell you how well you succeeded at a particular task: they tell you whether or not you overcame a story obstacle, which moves the story in a new direction.
+Contests in QuestWorlds don’t simply tell you how well you performed at a particular task: they tell you whether or not you overcame a story obstacle, which moves the story in a new direction. Unlike some other role-playing games, a contest in QuestWorlds does not resolve a task, it resolves the whole obstacle.
 
-If you need to break into the vault within the government headquarters and steal the secret codes, that is an obstacle, and the contest resolves that. As part of that obstacle there may be tasks: sneaking past the guards, picking the locks or lowering yourself from the cieling to avoid the pressure sensors, but they are not the obstacle. 
+If you need secret records which are stored in a vault within a government compound, your goal is to get the information - while the fact that it is secured against your access is an obstacle you must overcome to attain that goal. Overcoming that obstacle may involve many possible tasks, evading guards, lockpicking, forging credentials, etc. - but the contest doesn't address those individually. The contest is framed around the entire conflict against the obstacle as a whole.
 
-In a fight, your obstacle may be the opponents themselves, who you are fighting to capture or kill. Just as often you are seeking another goal and you only want to incapacitate enemy combatants to get it. In this case, beating the enemy is a task, not the obstacle. For example the obstacle might be proof of the accused's innocence in a trial by combat, freeing a captive from the villain's lair, or intimidating a group into surrendering.
+In a fight, your obstacle may be the opponents themselves, who you are fighting to capture or kill. Just as often you are seeking another goal and you might just as easily attain it by incapacitating or evading your foes. In this case, beating the enemy is a task, not the obstacle. For example, if an ally has been accused of treason by the King, your goal could be to prove the ally's innocence. The power of the King threatening your ally is an obstacle to be overcome, and a trial by combat could be a contest to resolve the conflict with an ability like "Knight Errant."
 
-In a court trial, your obstacle might be the opposing lawyer, who you want to humiliate. More likely you are seeking to free the innocent, or convict the guilty and bring justice. In this case, jury selection, a closing argument, revelatory evidence, or legal procedural challenges are tasks, not the obstacle. 
+In a court trial, your goal is likely a particular verdict, while the obstacle might be the opposing lawyer, an unjust law, or even the justice system itself.  In this case, jury selection, a closing argument, revelatory evidence, or legal procedural challenges are tasks, not the entire obstacle. The overall conflict encompasses all those things.
 
-Unlike some other role-playing games, a contest in QuestWorlds does not resolve a task, it resolves the whole obstacle.
-
-An obstacle moves the story forward when it is resolved. If it is merely a step toward resolving an obstacle it is a task and not a conflict. Your GM should be sure to look for the story obstacle when framing a conflict.
+A conflict to overcome obstacle moves the story forward when it is resolved. If it is merely a step toward resolving an obstacle it is a task and not a conflict. While those component tasks may be interesting parts of narrating tactics and results, your GM should be sure to look for the story obstacle in conflict when framing a contest.
 
 If there is no story obstacle to your actions, your GM should not call for a contest but simply let you narrate what you do, provided that seems credible.
 
-For example, you are travelling from one star system to another. In the next star system you hope to confront the aged rebel who holds long-forgotten secrets that could bring freedom to the galaxy. Your GM feel there is no useful story obstacle for you to contest against, and so lets you describe heading down to the spaceport to secure a ship, meeting the captain and crew of your vessel, and traveling to the next world. Your GM encourages you to summarize what happens quickly so you can get to the meeting with the old rebel. Your GM knows that will be the real story obstacle, convincing the old rebel to part with his secrets.
+For example, you are travelling from one star system to another. In the next star system you hope to confront the aged rebel who holds long-forgotten secrets that could bring freedom to the galaxy. Your GM feels there is no useful story obstacle for you to contest against, and so lets you describe heading down to the spaceport to secure a ship, meeting the captain and crew of your vessel, and traveling to the next world. Your GM encourages you to summarize what happens quickly so you can get to the meeting with the old rebel. Your GM knows that will be the real story obstacle, convincing the old rebel to part with his secrets.
 
-An optional rule, Long Contests, lets you drill-down when it is important we see you succeeding at a series of tasks in order to overcome the obstacle, such as trading blow with the king's champion in front of the tower where your sister is held hostage, or exposing the lies of a witness in the court room to free a wrongly accused innocent man.
+An optional rule, Long Contests, lets you zoom-in to task-level contests when it is more fun and interesting to play out struggling with a series of tasks in order to overcome the obstacle, such as blow-by-blow exchanges with the king's champion in front of the tower where your father is held hostage, or exposing the lies of a witness in the court room to free a wrongly accused innocent man. See §8 for details.
 
 #### 2.3.2.2 Tactics
 


### PR DESCRIPTION
In addition to some basic clean-ups, context touches, and smooth-outs, I do a lot of digging into consistent use of key terms and concepts here.

One thing I notice in particular is the absence in the current draft of goal-setting as a concept. I have endeavored to restore that here alongside the new obstacle terminology and harmonize them.

I also made consistent use of terms in the following manor:
conflict - overall struggle to overcome obstacle and achieve goal
contest - conceptual framework to resolve conflict
success/failure - results of your die-rolls during the contest
victory/defeat - results of the overall conflict

This sort of semantic rigor while tedious, is (in my view) key to creating an effective specification. S/F vs V/D in particular is something I've seen trip up even experienced gamers.