### PR TITLE
[Error]Improve glossary description of result

### DIFF
--- a/9.1_Glossary_of_Terms.md
+++ b/9.1_Glossary_of_Terms.md
@@ -160,7 +160,7 @@
 
 **Resource** A community **ability** that your PC may draw on.
 
-**Result** The **outcome** of a die roll against a **TN**. One of **critical**, **success**, **failure**, and **fumble**.
+**Result** The effect of a die roll against a **TN**. One of **critical**, **success**, **failure**, and **fumble**.
 
 **Retainer** A **follower** of your PC who is not 'fleshed out' and cannot act independently.
 


### PR DESCRIPTION
As per #14, the description of result in the glossary used a highlighted game term **outcome**. The highlight was a mistake as the result is not an outcome in game terms. In addition, the use of the world outcome is likely to cause confusion with the game term, even if we do not bold it. For this reason we have changed the word to 'effect' instead, which should be clearer.