### PR TITLE
[Fix] Issue 19 Add discussion of starting ratings for breakouts

### DIFF
--- a/3.2_Assigning_Ability_Ratings.md
+++ b/3.2_Assigning_Ability_Ratings.md
@@ -2,9 +2,11 @@
 
 You have now defined your **abilities**. These tell everyone what you can do. Now assign numbers to each **ability**, called **ratings**, which determine how well you can do these things.
 
- Assign a starting **rating** of 17 to the **ability** you find most important or defining. Although most players consider it wisest to assign this **rating** to their **occupational keyword**, you don’t have to do this. Assign a **rating** of 17 to your **distinguishing characteristic**. In some cases, you may treat your **distinguishing characteristic** as a **breakout ability** from a **keyword** in this case, treat it as a +4.
+Assign a starting **rating** of 17 to the **ability** you find most important or defining. Although most players consider it wisest to assign this **rating** to their **occupational keyword**, you don’t have to do this. Assign a **rating** of 17 to your **distinguishing characteristic**.
 
- All other **abilities** start at a **rating** of 13.
+All other **abilities** start at a **rating** of 13.
+
+A **breakout** from a **keyword** starts at +1. In some cases, you may treat your **distinguishing characteristic** as a **breakout ability** from a **keyword** in this case, treat it as a +4.
 
 Now spend up to 20 points to increase any of your various **ratings**, including **keywords**. Each point spent increases a **rating** by 1 point. You can’t spend more than 10 points on any one **ability**.
 


### PR DESCRIPTION
Adds an explicit discussion of breakout ratings as per #19 and moves the discussion of distinguishing characteristic as breakout ability to the same paragraph