### PR TITLE
Move to threshold from quantity, rephrase for clarity

### DIFF
--- a/2.1_Abilities.md
+++ b/2.1_Abilities.md
@@ -22,9 +22,9 @@ In summary, to reflect abilities (or **resistance**s), higher than 20, you divid
 
 You may sometimes be faced with a **story obstacle** for which you have no relevant **ability** whatsoever. In such cases, you may still enter into conflict with the **story obstacle** using a minimum base **target number** of 6 for your **contest** roll. Like **ratings**, it may also be subject to **modifiers**.
 
-#### 2.1.1.2 Making Ratings Quantitative
+#### 2.1.1.2 Using Ratings As thresholds
 
-While *QuestWorlds* generally treats **ratings** as abstract measures of problem solving power rather than quantitive measures of in-fiction traits, some games may also depart from this practice in order to more closely couple key fictional elements to the mechanics. For example, a magic system might classify certain supernatural effects as Apprentice, Journeyman, or Master level, and require **ratings** of 15, 5M, or 1M2 (respectively) in a relevant **ability** to even attempt them. 
+*QuestWorlds* treats **ratings** as a measure of how effective you are at solving problems with the **ability**, and does not limit what you can do with that **ability**, provided your actions are credible in genre. Where an important part of the genre is that certain uses of the **ability** are only available when you pass a threshold of experience, often through overcoming story obstacles to improve the **ability** in game, you may chose to set threshold **ratings** for those **abilities**. For example, a magic system might classify certain supernatural effects as Apprentice, Journeyman, or Master level, and require **ratings** of 15, 5M, or 1M2 (respectively) in a relevant **ability** to even attempt them.
 
 Such departures from abstraction should generally only be made where the increased complexity they bring leads to rewarding choices in a key area of interest to the setting or genre at hand. In most cases, you and your GM can simply follow the fiction surrounding your **ability** and its context within the setting for guidance as to what applications of the **ability** are credible.
 


### PR DESCRIPTION
This is a proposed fix for #21 and removes the use of quantitative and rephrases for clarity