### PR TITLE
[Fix] Clarify you can spend hero points on your own roll too

### DIFF
--- a/4.5_Advanced_Group_Simple_Contest.md
+++ b/4.5_Advanced_Group_Simple_Contest.md
@@ -42,7 +42,7 @@ The cost varies by the number of PCs participating:
 * 3 **hero points** for 7-9 PCs.  
 * and so on...
 
-You may spend twice as many **hero points** as required to gain a **double boost**. The points may be spent by any combination of players. They remain spent no matter how the **contest** resolves.
+You may spend twice as many **hero points** as required to gain a **double boost**. The points may be spent by any combination of players. They remain spent no matter how the **contest** resolves. You may continue to spend **hero points** to **bump** your individual **result**.
 
 The **boost** increases the collective **victory** level by one step. A **double boost** increases it by two steps.
 


### PR DESCRIPTION
Clarified the position on spending hero points to bump your own roll as per #48 