### PR TITLE
Fix typo and whitespace in 0.1

### DIFF
--- a/0.1_Legal_Information.md
+++ b/0.1_Legal_Information.md
@@ -1,6 +1,6 @@
 ## 0.1 Legal Information
 
-IncThe *QuestWorlds* System Reference Document 0.51 (“QWSRD0.51”) describes the rules of *QuestWorlds*. You may incorporate the rules as they appear in QWSRD0.51, wholly or in part, into a derivative work, through the use of the *QuestWorlds* Open Game License, Version 1.0. You should read and understand the terms of that License before creating a derivative work from QWSRD0.51.
+The *QuestWorlds* System Reference Document 0.51 (“QWSRD0.51”) describes the rules of *QuestWorlds*. You may incorporate the rules as they appear in QWSRD0.51, wholly or in part, into a derivative work, through the use of the *QuestWorlds* Open Game License, Version 1.0. You should read and understand the terms of that License before creating a derivative work from QWSRD0.51.
 
 Thanks to Wizards of the Coast, the Open Source Initiative, and Creative Commons for their work in creating the framework behind Open Source (and in this case Open Game) licenses. You should be aware that the *QuestWorlds* Open Game License for use of the *QuestWorlds* system differs from the Wizards Open Game License and has
 different terms and conditions.
@@ -77,3 +77,4 @@ except as expressly licensed in another, independent Agreement with the owner of
 16. Severability: If any provision of this License is held to be unenforceable, such provision shall be severed only to the extent necessary to make it enforceable.
 
 17. Governing Law and Venue: The governing law for any disputes arising under this License shall be the laws of the State of Michigan, without reference to its choice of laws provisions. Venue is exclusively vested in the United States Federal District Court for the Eastern District of Michigan.
+


### PR DESCRIPTION
- Removes "Inc" typo at beginning
- Adds the missing necessary whitespace at the end so that 0.2 Credits header works again