### PR TITLE
Success roll definition without mention of fumbles

### DIFF
--- a/2.3_Contest_Procedure.md
+++ b/2.3_Contest_Procedure.md
@@ -150,7 +150,7 @@ To determine how well you use an **ability**, roll a 20-sided die (D20). At the 
 Compare your rolled number with your **Target Number** to determine the **result**, a level of **success** or **failure** for the roll (not the **contest** as a whole).
 
 * **Critical**: If the die roll is equal to the **TN** (even when the **TN** is 20), you succeed brilliantly. This is the best **result** possible.
-* **Success**: If the die roll is less than the **TN** and not a **fumble**, you succeed, but there is nothing remarkable about the success.
+* **Success**: If the die roll is less than the **TN**, you succeed, but there is nothing remarkable about the success.
 * **Failure**: If the die roll is greater than the **TN** but not a **fumble**, you fail. Things do not happen as hoped.
 * **Fumble**: If the die roll is 20, you fumble (except when the **TN** is 20, when it is a **critical**). You fail miserably. This is the worst **result** possible.
 


### PR DESCRIPTION
Revises the definition of a success roll in 2.3.5 to not mention fumbles. Since it's not possible to roll under the TN and fumble, it's an unnecessary caveat that it likely to cause confusion.

Closes #94