### PR TITLE
Remove dead link from 0.1_Legal_Information.md--fixes #164

### DIFF
--- a/0.1_Legal_Information.md
+++ b/0.1_Legal_Information.md
@@ -13,7 +13,7 @@ If you have questions about this license, please reach out to Moon Design at lic
 
 ### 0.1.2 *QuestWorlds* ORC License Statement
 
-This product is licensed under the ORC License held in the Library of Congress at TX 9-307-067 and available online at various locations including www.chaosium.com/orclicense, www.azoralaw.com/orclicense, www.gencon.com/orclicense and others. All warranties are disclaimed as set forth therein.
+This product is licensed under the ORC License held in the Library of Congress at TX 9-307-067 and available online at various locations including www.chaosium.com/orclicense, www.azoralaw.com/orclicense, and others. All warranties are disclaimed as set forth therein.
 
 This product is the original work of Moon Design Publications.
 


### PR DESCRIPTION
This removes the dead ORC license link to gencon.com from the section 0.1. They don't seem to host the license text any longer.
Fix for issue #164. 