### PR TITLE
Fixing heading level

### DIFF
--- a/0.1_Legal_Information.md
+++ b/0.1_Legal_Information.md
@@ -1,4 +1,4 @@
-# 0.1 Legal Information
+## 0.1 Legal Information
 
 The *QuestWorlds* System Reference Document 0.97 (“QWSRD0.97”) describes the rules of *QuestWorlds*. You may incorporate the rules as they appear in QWSRD0.97, wholly or in part, into a derivative work, through the use of the ORC License. You should read and understand the terms of that License before creating a derivative work from QWSRD0.97.
 


### PR DESCRIPTION
The 0.1 section should begin with a level 2 heading (`## 0.1 Legal Information`) and not a level 1 heading (`# 0.1 Legal Information`) to keep it consistent with other X.Y sections